### PR TITLE
nvim-treesitterを導入する

### DIFF
--- a/.config/alacritty/alacritty.yml
+++ b/.config/alacritty/alacritty.yml
@@ -8,41 +8,63 @@ shell:
     - "tmux attach || tmux"
 colors:
   primary:
-    foreground: "#b3b1ad"
-    background: "#0a0e14"
-  normal:
-    black: "#0a0e14"
-    red: "#f07178"
-    green: "#c2d94c"
-    yellow: "#e6b450"
-    blue: "#39bae6"
-    magenta: "#ffb454"
-    cyan: "#36a3d9"
-    white: "#b3b1ad"
+    # hard contrast background - '#1d2021'
+    background: &gruvbox_dark_bg "#282828"
+    # soft contrast background - '#32302f'
+    foreground: "#ebdbb2"
+    bright_foreground: "#fbf1c7"
+    dim_foreground: "#a89984"
+  cursor:
+    text: CellBackground
+    cursor: CellForeground
+  vi_mode_cursor:
+    text: CellBackground
+    cursor: CellForeground
+  selection:
+    text: CellBackground
+    background: CellForeground
   bright:
-    black: "#0a0e14"
-    red: "#ff3333"
-    green: "#c2d94c"
-    yellow: "#e6b450"
-    blue: "#39bae6"
-    magenta: "#f07178"
-    cyan: "#59c2ff"
-    white: "#b3b1ad"
+    black: "#928374"
+    red: "#fb4934"
+    green: "#b8bb26"
+    yellow: "#fabd2f"
+    blue: "#83a598"
+    magenta: "#d3869b"
+    cyan: "#8ec07c"
+    white: "#ebdbb2"
+  normal:
+    black: *gruvbox_dark_bg
+    red: "#cc241d"
+    green: "#98971a"
+    yellow: "#d79921"
+    blue: "#458588"
+    magenta: "#b16286"
+    cyan: "#689d6a"
+    white: "#a89984"
+  dim:
+    black: "#32302f"
+    red: "#9d0006"
+    green: "#79740e"
+    yellow: "#b57614"
+    blue: "#076678"
+    magenta: "#8f3f71"
+    cyan: "#427b58"
+    white: "#928374"
 font:
   size: 12
   normal:
-    family: 'HackGen35Nerd'
-    style:  Regular
+    family: "HackGen35Nerd"
+    style: Regular
   bold:
-    family: 'HackGen35Nerd'
-    style:  Bold
+    family: "HackGen35Nerd"
+    style: Bold
   italic:
-    family: 'HackGen35Nerd'
-    style:  Italic
+    family: "HackGen35Nerd"
+    style: Italic
   bold_italic:
-    family: 'HackGen35Nerd'
-    style:  Bold Italic
+    family: "HackGen35Nerd"
+    style: Bold Italic
 window:
-  decorations:  full
+  decorations: full
   startup_mode: Windowed
   opacity: 0.95

--- a/.config/nvim/colorscheme.vim
+++ b/.config/nvim/colorscheme.vim
@@ -10,7 +10,7 @@ if (has("termguicolors"))
 endif
 
 set background=dark
-colorscheme ayu
+colorscheme gruvbox
 
 if g:colors_name == 'ayu'
   let ayucolor='dark' " available: light / dark / mirage

--- a/.config/nvim/plugins/config/dein.toml
+++ b/.config/nvim/plugins/config/dein.toml
@@ -59,6 +59,13 @@ hook_add = """
 source ~/.config/nvim/plugins/coc.rc.vim
 """
 
+[[plugins]]
+repo = "nvim-treesitter/nvim-treesitter"
+merged = 0
+hook_add = """
+source ~/.config/nvim/plugins/nvim-treesitter.rc.vim
+"""
+
 ##############################
 # Dark Power plugins #########
 ##############################

--- a/.config/nvim/plugins/nvim-treesitter.rc.vim
+++ b/.config/nvim/plugins/nvim-treesitter.rc.vim
@@ -1,0 +1,14 @@
+lua <<EOF
+require'nvim-treesitter.configs'.setup {
+  highlight = {
+    enable = true,
+    disable = {
+      'lua',
+      'ruby',
+      'toml',
+      'c_sharp',
+      'vue',
+    }
+  }
+}
+EOF

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -21,7 +21,7 @@ set-option -g status-style fg=$foreground,bg=$background
 set-option -g status-left-length 20
 set-option -g status-left "#[fg=$status_foreground,bg=$status_background] SESSION: #S WINDOW: #I PANE: #P #[default]"
 set-option -g status-left-length 50
-set-option -g status-right "#[fg=$status_foreground,bg=$status_background] %m/%d %H:%M:%S #[default]"
+# set-option -g status-right "#[fg=$status_foreground,bg=$status_background] %m/%d %H:%M:%S #[default]"
 set-option -g status-justify "centre"
 
 # Window
@@ -98,3 +98,54 @@ bind l select-pane -R
 # Use 256 colors
 set -g default-terminal "screen-256color"
 set-option -sa terminal-overrides ',alacritty:RGB'
+
+## COLORSCHEME: gruvbox dark (medium)
+set-option -g status "on"
+
+# default statusbar color
+set-option -g status-style bg=colour237,fg=colour223 # bg=bg1, fg=fg1
+
+# default window title colors
+set-window-option -g window-status-style bg=colour214,fg=colour237 # bg=yellow, fg=bg1
+
+# default window with an activity alert
+set-window-option -g window-status-activity-style bg=colour237,fg=colour248 # bg=bg1, fg=fg3
+
+# active window title colors
+set-window-option -g window-status-current-style bg=red,fg=colour237 # fg=bg1
+
+# pane border
+set-option -g pane-active-border-style fg=colour250 #fg2
+set-option -g pane-border-style fg=colour237 #bg1
+
+# message infos
+set-option -g message-style bg=colour239,fg=colour223 # bg=bg2, fg=fg1
+
+# writing commands inactive
+set-option -g message-command-style bg=colour239,fg=colour223 # bg=fg3, fg=bg1
+
+# pane number display
+set-option -g display-panes-active-colour colour250 #fg2
+set-option -g display-panes-colour colour237 #bg1
+
+# clock
+set-window-option -g clock-mode-colour colour109 #blue
+
+# bell
+set-window-option -g window-status-bell-style bg=colour167,fg=colour235 # bg=red, fg=bg
+
+## Theme settings mixed with colors (unfortunately, but there is no cleaner way)
+set-option -g status-justify "left"
+set-option -g status-left-style none
+set-option -g status-left-length "80"
+set-option -g status-right-style none
+set-option -g status-right-length "80"
+set-window-option -g window-status-separator ""
+
+set-option -g status-left "#[bg=colour241,fg=colour248] #S #[bg=colour237,fg=colour241,nobold,noitalics,nounderscore]"
+set-option -g status-right "#[bg=colour237,fg=colour239 nobold, nounderscore, noitalics]#[bg=colour239,fg=colour246] %Y-%m-%d  %H:%M:%S #[bg=colour239,fg=colour248,nobold,noitalics,nounderscore]#[bg=colour248,fg=colour237] #h "
+
+set-window-option -g window-status-current-format "#[bg=colour214,fg=colour237,nobold,noitalics,nounderscore]#[bg=colour214,fg=colour239] #I #[bg=colour214,fg=colour239,bold] #W#{?window_zoomed_flag,*Z,} #[bg=colour237,fg=colour214,nobold,noitalics,nounderscore]"
+set-window-option -g window-status-format "#[bg=colour239,fg=colour237,noitalics]#[bg=colour239,fg=colour223] #I #[bg=colour239,fg=colour223] #W #[bg=colour237,fg=colour239,noitalics]"
+
+# vim: set ft=tmux tw=0 nowrap:

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -3,34 +3,14 @@
 ##############################
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-sensible'
-
 run -b '~/.tmux/plugins/tpm/tpm'
-
-##############################
-# Theme                      #
-##############################
-foreground="#b3b1ad"
-background="#0a0e14"
-status_foreground="#C2D94C"
-status_background="#273747"
-window_active_foreground="#e6b450"
-
-set-option -g status-interval 1
-
-set-option -g status-style fg=$foreground,bg=$background
-set-option -g status-left-length 20
-set-option -g status-left "#[fg=$status_foreground,bg=$status_background] SESSION: #S WINDOW: #I PANE: #P #[default]"
-set-option -g status-left-length 50
-# set-option -g status-right "#[fg=$status_foreground,bg=$status_background] %m/%d %H:%M:%S #[default]"
-set-option -g status-justify "centre"
-
-# Window
-set-window-option -g window-status-format " #I: #W #[default]"
-set-window-option -g window-status-current-format "#[fg=$window_active_foreground,bg=$background,bold] #I: #W #[default]"
 
 ##############################
 # Config                     #
 ##############################
+# Interval
+set-option -g status-interval 1
+
 # Change the prefix to Ctrl+g
 unbind-key C-b
 set -g prefix C-g
@@ -142,7 +122,7 @@ set-option -g status-right-style none
 set-option -g status-right-length "80"
 set-window-option -g window-status-separator ""
 
-set-option -g status-left "#[bg=colour241,fg=colour248] #S #[bg=colour237,fg=colour241,nobold,noitalics,nounderscore]"
+set-option -g status-left "#[bg=colour241,fg=colour248] #P #[bg=colour237,fg=colour241,nobold,noitalics,nounderscore]"
 set-option -g status-right "#[bg=colour237,fg=colour239 nobold, nounderscore, noitalics]#[bg=colour239,fg=colour246] %Y-%m-%d  %H:%M:%S #[bg=colour239,fg=colour248,nobold,noitalics,nounderscore]#[bg=colour248,fg=colour237] #h "
 
 set-window-option -g window-status-current-format "#[bg=colour214,fg=colour237,nobold,noitalics,nounderscore]#[bg=colour214,fg=colour239] #I #[bg=colour214,fg=colour239,bold] #W#{?window_zoomed_flag,*Z,} #[bg=colour237,fg=colour214,nobold,noitalics,nounderscore]"


### PR DESCRIPTION
Neovimのシンタックスハイライトを強化する
[nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter)

- ayu-vim が nvim-treesitter に対応していなかったので colorscheme を gruvbox に変更
    - tmux 変更済み
    - alacritty 変更済み