### PR TITLE
setup_fontタスクが動くように修正

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -25,7 +25,7 @@ jobs:
       env:
         GIT_NAME: pyama2000
         GIT_EMAIL: example@example.com
-    - name: Setup alacritty 
+    - name: Setup font
       if: always()
       run: cargo make --makefile script/task.toml setup_font
     - name: Setup alacritty 

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -27,6 +27,9 @@ jobs:
         GIT_EMAIL: example@example.com
     - name: Setup alacritty 
       if: always()
+      run: cargo make --makefile script/task.toml setup_font
+    - name: Setup alacritty 
+      if: always()
       run: cargo make --makefile script/task.toml setup_alacritty
     - name: Setup tmux
       if: always()

--- a/script/tasks/font.toml
+++ b/script/tasks/font.toml
@@ -5,6 +5,7 @@ run_task = [{ name = ["download_PlemolJP_NF", "apply_font"] }]
 script = [
 '''
 #!/usr/bin/env bash
+set -eux -o pipefail
 
 FONT_NAME='PlemolJP_NF'
 ENDPOINT='https://api.github.com/repos/yuru7/PlemolJP/releases/latest'
@@ -29,6 +30,7 @@ rm -rf "$FONT_NAME"
 script = [
 '''
 #!/usr/bin/env bash
+set -eux -o pipefail
 
 FONT_NAME='PlemolJP_NF'
 
@@ -40,6 +42,7 @@ cp -a ~/.fonts/"$FONT_NAME"/* ~/Library/Fonts
 script = [
 '''
 #!/usr/bin/env bash
+set -eux -o pipefail
 
 FONT_NAME='PlemolJP_NF'
 

--- a/script/tasks/font.toml
+++ b/script/tasks/font.toml
@@ -36,7 +36,9 @@ set -eux -o pipefail
 
 FONT_NAME='PlemolJP_NF'
 
-ls -la ~/Library/Fonts
+if [ ! -d "$HOME/Library/Fonts" ]; then
+  mkdir -p "$HOME"/Library/Fonts
+fi
 
 cp -a ~/.fonts/"$FONT_NAME"/* ~/Library/Fonts
 '''

--- a/script/tasks/font.toml
+++ b/script/tasks/font.toml
@@ -2,6 +2,7 @@
 run_task = [{ name = ["download_PlemolJP_NF", "apply_font"] }]
 
 [tasks.download_PlemolJP_NF]
+private = true
 script = [
 '''
 #!/usr/bin/env bash
@@ -27,6 +28,7 @@ rm -rf "$FONT_NAME"
 ]
 
 [tasks.apply_font.mac]
+private = true
 script = [
 '''
 #!/usr/bin/env bash
@@ -39,6 +41,7 @@ cp -a ~/.fonts/"$FONT_NAME"/* ~/Library/Fonts
 ]
 
 [tasks.apply_font.linux]
+private = true
 script = [
 '''
 #!/usr/bin/env bash

--- a/script/tasks/font.toml
+++ b/script/tasks/font.toml
@@ -36,6 +36,8 @@ set -eux -o pipefail
 
 FONT_NAME='PlemolJP_NF'
 
+ls -la ~/Library/Fonts
+
 cp -a ~/.fonts/"$FONT_NAME"/* ~/Library/Fonts
 '''
 ]


### PR DESCRIPTION
Overview
===

Close https://github.com/pyama2000/dotfiles/issues/105

- setup_fontタスクが動くように修正
- setupタスクのsetup_fontタスクの順番を変更
    - 依存するタスクがないためcleanupタスクの前に移動