### PR TITLE
fix: エラーが起きる設定を修正

### DIFF
--- a/.github/workflows/re-run.yaml
+++ b/.github/workflows/re-run.yaml
@@ -24,7 +24,7 @@ jobs:
           status=$(
             gh run list \
               --workflow check.yaml \
-              --branch "${{ github.event.pull_request.head.ref }}" \
+              --branch "$GITHUB_HEAD_REF" \
               --limit 1 \
               --json status \
             | jq -r '.[].status'

--- a/nvim/lua/options.lua
+++ b/nvim/lua/options.lua
@@ -18,8 +18,7 @@ vim.opt.signcolumn = "yes"
 vim.opt.autoread = true
 vim.cmd([[
   augroup autoreload-checktime
-    autocmd!
-    autocmd CursorHold,CursorHoldI,CursorMoved,CursorMovedI,BufEnter * checktime
+    autocmd CursorHold,CursorHoldI,CursorMoved,CursorMovedI,BufEnter * silent! checktime
   augroup END
 ]])
 

--- a/nvim/lua/plugins/null-ls.lua
+++ b/nvim/lua/plugins/null-ls.lua
@@ -10,6 +10,7 @@ return {
     null_ls.setup({
       sources = {
         null_ls.builtins.formatting.stylua,
+        null_ls.builtins.diagnostics.actionlint,
       },
     })
   end,

--- a/nvim/lua/plugins/telescope.lua
+++ b/nvim/lua/plugins/telescope.lua
@@ -50,7 +50,7 @@ return {
       vim.keymap.set("n", "<C-d>c", builtin.command_history, { noremap = true, silent = true })
       vim.keymap.set("n", "<C-d>s", builtin.search_history, { noremap = true, silent = true })
       vim.keymap.set({ "n", "x" }, "<C-d>g", builtin.grep_string, { noremap = true, silent = true })
-      vim.keymap.set("n", "<C-d>h", "<cmd>Telescope find_files --hidden=true<CR>", { noremap = true, silent = true })
+      vim.keymap.set("n", "<C-d>h", "<cmd>Telescope find_files hidden=true<CR>", { noremap = true, silent = true })
       vim.keymap.set("n", "<C-d>of", "<cmd>Telescope find_files ", { noremap = true, silent = true })
       vim.keymap.set("n", "<C-f>b", telescope.extensions.file_browser.file_browser, { noremap = true, silent = true })
     end,


### PR DESCRIPTION
# Overview

- GitHub Actions の `re-run` workflow 内の `run` で PR のブランチ名を取得するために環境変数（ `GITHUB_HEAD_REF` ）を利用する
- actionlint による linter の設定を追加
- Telescope で hidden の指定方法を修正
- checktime の autocmd でエラーを表示しないようにする
