### PR TITLE
nvim-cmp の設定を修正

### DIFF
--- a/nvim/lua/plugins/mason-lspconfig.lua
+++ b/nvim/lua/plugins/mason-lspconfig.lua
@@ -5,27 +5,6 @@ return {
     "neovim/nvim-lspconfig",
   },
   config = function()
-    local cmp = require("cmp")
-    cmp.setup({
-      snippet = {
-        expand = function(args)
-          vim.fn["vsnip#anonymous"](args.body)
-        end,
-      },
-      sources = cmp.config.sources({
-        { name = "nvim_lsp" },
-        { name = "nvim_lsp_signature_help" },
-        { name = "vsnip" },
-      }, {
-        { name = "buffer" },
-      }),
-      mapping = cmp.mapping.preset.insert({
-        ["<Tab>"] = cmp.mapping.select_next_item(),
-        ["<S-Tab>"] = cmp.mapping.select_prev_item(),
-        ["<CR>"] = cmp.mapping.confirm({ select = true }),
-      }),
-    })
-
     require("mason")
 
     local nvim_lsp = require("lspconfig")

--- a/nvim/lua/plugins/nvim-cmp.lua
+++ b/nvim/lua/plugins/nvim-cmp.lua
@@ -1,5 +1,6 @@
 return {
   "hrsh7th/nvim-cmp",
+  event = { "InsertEnter", "CmdlineEnter" },
   dependencies = {
     "hrsh7th/cmp-buffer",
     "hrsh7th/cmp-cmdline",

--- a/nvim/lua/plugins/nvim-cmp.lua
+++ b/nvim/lua/plugins/nvim-cmp.lua
@@ -1,6 +1,32 @@
 return {
   "hrsh7th/nvim-cmp",
   dependencies = {
+    "hrsh7th/cmp-buffer",
+    "hrsh7th/cmp-nvim-lsp",
+    "hrsh7th/cmp-nvim-lsp-signature-help",
     { "ray-x/cmp-treesitter", dependencies = { "nvim-treesitter/nvim-treesitter" } },
+    { "hrsh7th/cmp-vsnip", dependencies = { "hrsh7th/vim-vsnip" } },
   },
+  config = function()
+    local cmp = require("cmp")
+    cmp.setup({
+      snippet = {
+        expand = function(args)
+          vim.fn["vsnip#anonymous"](args.body)
+        end,
+      },
+      sources = cmp.config.sources({
+        { name = "nvim_lsp" },
+        { name = "nvim_lsp_signature_help" },
+        { name = "vsnip" },
+      }, {
+        { name = "buffer" },
+      }),
+      mapping = cmp.mapping.preset.insert({
+        ["<Tab>"] = cmp.mapping.select_next_item(),
+        ["<S-Tab>"] = cmp.mapping.select_prev_item(),
+        ["<CR>"] = cmp.mapping.confirm({ select = true }),
+      }),
+    })
+  end,
 }

--- a/nvim/lua/plugins/nvim-cmp.lua
+++ b/nvim/lua/plugins/nvim-cmp.lua
@@ -4,6 +4,7 @@ return {
     "hrsh7th/cmp-buffer",
     "hrsh7th/cmp-nvim-lsp",
     "hrsh7th/cmp-nvim-lsp-signature-help",
+    "hrsh7th/cmp-path",
     { "ray-x/cmp-treesitter", dependencies = { "nvim-treesitter/nvim-treesitter" } },
     { "hrsh7th/cmp-vsnip", dependencies = { "hrsh7th/vim-vsnip" } },
   },
@@ -18,9 +19,11 @@ return {
       sources = cmp.config.sources({
         { name = "nvim_lsp" },
         { name = "nvim_lsp_signature_help" },
+        { name = "path" },
         { name = "vsnip" },
       }, {
         { name = "buffer" },
+        { name = "treesitter" },
       }),
       mapping = cmp.mapping.preset.insert({
         ["<Tab>"] = cmp.mapping.select_next_item(),

--- a/nvim/lua/plugins/nvim-cmp.lua
+++ b/nvim/lua/plugins/nvim-cmp.lua
@@ -2,7 +2,9 @@ return {
   "hrsh7th/nvim-cmp",
   dependencies = {
     "hrsh7th/cmp-buffer",
+    "hrsh7th/cmp-cmdline",
     "hrsh7th/cmp-nvim-lsp",
+    "hrsh7th/cmp-nvim-lsp-document-symbol",
     "hrsh7th/cmp-nvim-lsp-signature-help",
     "hrsh7th/cmp-path",
     { "ray-x/cmp-treesitter", dependencies = { "nvim-treesitter/nvim-treesitter" } },
@@ -30,6 +32,25 @@ return {
         ["<S-Tab>"] = cmp.mapping.select_prev_item(),
         ["<CR>"] = cmp.mapping.confirm({ select = true }),
       }),
+    })
+    cmp.setup.cmdline("/", {
+      mapping = cmp.mapping.preset.cmdline(),
+      sources = cmp.config.sources({
+        { name = "nvim_lsp_document_symbol" },
+        { name = "cmdline" },
+      }, {
+        { name = "buffer" },
+      }),
+      completion = {
+        completeopt = "menu,menuone,noselect",
+      },
+    })
+    cmp.setup.cmdline(":", {
+      mapping = cmp.mapping.preset.cmdline(),
+      sources = cmp.config.sources({ { name = "path" } }, { { name = "cmdline" }, { { name = "cmdline_history" } } }),
+      completion = {
+        completeopt = "menu,menuone,noselect",
+      },
     })
   end,
 }

--- a/nvim/lua/plugins/nvim-lspconfig.lua
+++ b/nvim/lua/plugins/nvim-lspconfig.lua
@@ -4,8 +4,6 @@ return {
   -- FIXME: dependencies を整理する
   dependencies = {
     "williamboman/mason-lspconfig.nvim",
-    "hrsh7th/cmp-nvim-lsp-document-symbol",
-    "hrsh7th/cmp-cmdline",
     "b0o/schemastore.nvim",
   },
   config = function()

--- a/nvim/lua/plugins/nvim-lspconfig.lua
+++ b/nvim/lua/plugins/nvim-lspconfig.lua
@@ -5,7 +5,6 @@ return {
   dependencies = {
     "williamboman/mason-lspconfig.nvim",
     "hrsh7th/cmp-nvim-lsp-document-symbol",
-    "hrsh7th/cmp-path",
     "hrsh7th/cmp-cmdline",
     "b0o/schemastore.nvim",
   },

--- a/nvim/lua/plugins/nvim-lspconfig.lua
+++ b/nvim/lua/plugins/nvim-lspconfig.lua
@@ -4,14 +4,9 @@ return {
   -- FIXME: dependencies を整理する
   dependencies = {
     "williamboman/mason-lspconfig.nvim",
-    "hrsh7th/cmp-nvim-lsp",
     "hrsh7th/cmp-nvim-lsp-document-symbol",
-    "hrsh7th/cmp-nvim-lsp-signature-help",
-    "hrsh7th/cmp-buffer",
     "hrsh7th/cmp-path",
     "hrsh7th/cmp-cmdline",
-    "hrsh7th/vim-vsnip",
-    "hrsh7th/cmp-vsnip",
     "b0o/schemastore.nvim",
   },
   config = function()


### PR DESCRIPTION
# Overview

## Feature

- `InsertEnter` / `CmdlineEnter` 時に nvim-cmp を発火させる

## Fix

- nvim-lspconfig や mason-lspconfig に分散していた設定を nvim-cmp に集約する
- `path` / `cmdline` などの source を読み込む
