### PR TITLE
nvim-lspconfig の設定を修正

### DIFF
--- a/nvim/lazy-lock.json
+++ b/nvim/lazy-lock.json
@@ -10,6 +10,7 @@
   "fidget.nvim": { "branch": "main", "commit": "f1c375ba68839eaa4a65efdf2aa078c0da0548fe" },
   "kanagawa.nvim": { "branch": "master", "commit": "1749cea392acb7d1548a946fcee1e6f1304cd3cb" },
   "lazy.nvim": { "branch": "main", "commit": "4c8b625bc873ca76b76eee0c28c98f1f7148f17f" },
+  "lsp-format.nvim": { "branch": "master", "commit": "ca0df5c8544e51517209ea7b86ecc522c98d4f0a" },
   "lualine.nvim": { "branch": "master", "commit": "05d78e9fd0cdfb4545974a5aa14b1be95a86e9c9" },
   "mason-lspconfig.nvim": { "branch": "main", "commit": "4c3baba22189aa2a08d32bb8d08b32c7e22a2e84" },
   "mason-null-ls.nvim": { "branch": "main", "commit": "73c68abdf65279e41526eb152876511a8ae84ea2" },

--- a/nvim/lua/plugins/mason-lspconfig.lua
+++ b/nvim/lua/plugins/mason-lspconfig.lua
@@ -1,6 +1,7 @@
 return {
   "williamboman/mason-lspconfig.nvim",
   dependencies = {
+    "hrsh7th/cmp-nvim-lsp",
     "williamboman/mason.nvim",
     "neovim/nvim-lspconfig",
   },

--- a/nvim/lua/plugins/mason-lspconfig.lua
+++ b/nvim/lua/plugins/mason-lspconfig.lua
@@ -2,6 +2,7 @@ return {
   "williamboman/mason-lspconfig.nvim",
   dependencies = {
     "hrsh7th/cmp-nvim-lsp",
+    "lukas-reineke/lsp-format.nvim",
     "williamboman/mason.nvim",
     "neovim/nvim-lspconfig",
     "b0o/schemastore.nvim",
@@ -9,8 +10,10 @@ return {
   config = function()
     local mason_lspconfig = require("mason-lspconfig")
     local lspconfig = require("lspconfig")
+    local lsp_format = require("lsp-format")
 
     require("mason").setup({})
+    lsp_format.setup({})
 
     mason_lspconfig.setup({
       ensure_installed = {
@@ -36,6 +39,10 @@ return {
           opts.on_attach = function(client)
             client.server_capabilities.documentFormattingProvider = false
           end
+        end
+
+        if server_name == "terraformls" or server_name == "tflint" then
+          opts.on_attach = lsp_format.on_attach
         end
 
         if server_name == "yamlls" then

--- a/nvim/lua/plugins/mason-lspconfig.lua
+++ b/nvim/lua/plugins/mason-lspconfig.lua
@@ -6,10 +6,10 @@ return {
     "neovim/nvim-lspconfig",
   },
   config = function()
-    require("mason")
-
-    local nvim_lsp = require("lspconfig")
     local mason_lspconfig = require("mason-lspconfig")
+    local lspconfig = require("lspconfig")
+
+    require("mason").setup({})
 
     mason_lspconfig.setup({
       ensure_installed = {
@@ -25,12 +25,12 @@ return {
         "yamlls",
       },
     })
+
     mason_lspconfig.setup_handlers({
       function(server_name)
         local capabilities = require("cmp_nvim_lsp").default_capabilities()
-        nvim_lsp[server_name].setup({
-          capabilities = capabilities,
-        })
+        local opts = { capabilities = capabilities }
+        lspconfig[server_name].setup(opts)
       end,
     })
   end,

--- a/nvim/lua/plugins/mason-lspconfig.lua
+++ b/nvim/lua/plugins/mason-lspconfig.lua
@@ -14,14 +14,14 @@ return {
       ensure_installed = {
         "bashls",
         "bufls",
-        "rust_analyzer",
-        "lua_ls",
         "gopls",
         "jsonls",
-        "yamlls",
+        "lua_ls",
+        "pyright",
+        "rust_analyzer",
         "terraformls",
         "tflint",
-        "pyright",
+        "yamlls",
       },
     })
     mason_lspconfig.setup_handlers({

--- a/nvim/lua/plugins/mason-lspconfig.lua
+++ b/nvim/lua/plugins/mason-lspconfig.lua
@@ -32,6 +32,12 @@ return {
         local capabilities = require("cmp_nvim_lsp").default_capabilities()
         local opts = { capabilities = capabilities }
 
+        if server_name == "lua_ls" then
+          opts.on_attach = function(client)
+            client.server_capabilities.documentFormattingProvider = false
+          end
+        end
+
         if server_name == "yamlls" then
           opts.settings = {
             yaml = {

--- a/nvim/lua/plugins/mason-lspconfig.lua
+++ b/nvim/lua/plugins/mason-lspconfig.lua
@@ -4,6 +4,7 @@ return {
     "hrsh7th/cmp-nvim-lsp",
     "williamboman/mason.nvim",
     "neovim/nvim-lspconfig",
+    "b0o/schemastore.nvim",
   },
   config = function()
     local mason_lspconfig = require("mason-lspconfig")
@@ -30,6 +31,17 @@ return {
       function(server_name)
         local capabilities = require("cmp_nvim_lsp").default_capabilities()
         local opts = { capabilities = capabilities }
+
+        if server_name == "yamlls" then
+          opts.settings = {
+            yaml = {
+              schemas = require("schemastore").yaml.schemas(),
+              validate = true,
+              format = { enable = true },
+            },
+          }
+        end
+
         lspconfig[server_name].setup(opts)
       end,
     })

--- a/nvim/lua/plugins/mason.lua
+++ b/nvim/lua/plugins/mason.lua
@@ -1,6 +1,5 @@
 return {
   "williamboman/mason.nvim",
-  build = ":MasonUpdate",
   cmd = { "Mason" },
   opts = {
     ui = {

--- a/nvim/lua/plugins/nvim-lspconfig.lua
+++ b/nvim/lua/plugins/nvim-lspconfig.lua
@@ -1,6 +1,6 @@
 return {
   "neovim/nvim-lspconfig",
-  event = { "BufReadPre" },
+  event = { "BufReadPre", "BufNewFile" },
   config = function()
     vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(vim.lsp.handlers.hover, {
       border = "single",

--- a/nvim/lua/plugins/nvim-lspconfig.lua
+++ b/nvim/lua/plugins/nvim-lspconfig.lua
@@ -8,15 +8,6 @@ return {
   },
   config = function()
     local lspconfig = require("lspconfig")
-    lspconfig.rust_analyzer.setup({
-      settings = {
-        ["rust-analyzer"] = {
-          diagnostics = {
-            enable = false,
-          },
-        },
-      },
-    })
     lspconfig.yamlls.setup({
       settings = {
         yaml = {

--- a/nvim/lua/plugins/nvim-lspconfig.lua
+++ b/nvim/lua/plugins/nvim-lspconfig.lua
@@ -8,9 +8,6 @@ return {
   },
   config = function()
     local lspconfig = require("lspconfig")
-    lspconfig.bashls.setup({})
-    lspconfig.bufls.setup({})
-    lspconfig.lua_ls.setup({})
     lspconfig.rust_analyzer.setup({
       settings = {
         ["rust-analyzer"] = {
@@ -20,8 +17,6 @@ return {
         },
       },
     })
-    lspconfig.gopls.setup({})
-    lspconfig.intelephense.setup({})
     lspconfig.yamlls.setup({
       settings = {
         yaml = {
@@ -31,9 +26,6 @@ return {
         },
       },
     })
-    lspconfig.terraformls.setup({})
-    lspconfig.tflint.setup({})
-    lspconfig.pyright.setup({})
     vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(vim.lsp.handlers.hover, {
       border = "single",
     })

--- a/nvim/lua/plugins/nvim-lspconfig.lua
+++ b/nvim/lua/plugins/nvim-lspconfig.lua
@@ -4,19 +4,8 @@ return {
   -- FIXME: dependencies を整理する
   dependencies = {
     "williamboman/mason-lspconfig.nvim",
-    "b0o/schemastore.nvim",
   },
   config = function()
-    local lspconfig = require("lspconfig")
-    lspconfig.yamlls.setup({
-      settings = {
-        yaml = {
-          schemas = require("schemastore").yaml.schemas(),
-          validate = true,
-          format = { enable = true },
-        },
-      },
-    })
     vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(vim.lsp.handlers.hover, {
       border = "single",
     })

--- a/nvim/lua/plugins/nvim-lspconfig.lua
+++ b/nvim/lua/plugins/nvim-lspconfig.lua
@@ -9,8 +9,6 @@ return {
     vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(vim.lsp.handlers.hover, {
       border = "single",
     })
-    -- FIXME: on_attach が効かないので全ての client で format を有効にする
-    vim.cmd([[autocmd BufWritePre <buffer> lua vim.lsp.buf.format()]])
   end,
   keys = {
     {

--- a/nvim/lua/plugins/nvim-lspconfig.lua
+++ b/nvim/lua/plugins/nvim-lspconfig.lua
@@ -1,10 +1,6 @@
 return {
   "neovim/nvim-lspconfig",
   event = { "BufReadPre" },
-  -- FIXME: dependencies を整理する
-  dependencies = {
-    "williamboman/mason-lspconfig.nvim",
-  },
   config = function()
     vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(vim.lsp.handlers.hover, {
       border = "single",


### PR DESCRIPTION
# Overview

LSP の設定があちこちにバラついていたため setup で不具合が出ていたので mason-lspconfig の `setup_handler` 内で設定する
また、mason-lspconfig に統一したことで format on save してくれる [lsp-format](https://github.com/lukas-reineke/lsp-format.nvim) を利用できるようになったので導入した
