### PR TITLE
fix: brew コマンドが存在しなかったらインストールする

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -24,7 +24,9 @@ if [ $OS == "Linux" ]; then
 
   sudo apt autoremove -y
 elif [ $OS == "macOS" ]; then
-  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  if ! (type brew >/dev/null 2>&1); then
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  fi
 fi
 
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y


### PR DESCRIPTION
# Overview

GitHub Actions で `brew` コマンドをインストールするのに失敗しているので、存在チェックする
