### PR TITLE
shfmt でのフォーマット形式を指定する

### DIFF
--- a/nvim/lua/plugins/null-ls.lua
+++ b/nvim/lua/plugins/null-ls.lua
@@ -23,7 +23,9 @@ return {
         formatting.buf,
         formatting.fish_indent,
         formatting.goimports,
-        formatting.shfmt,
+        formatting.shfmt.with({
+          extra_args = { "--indent", "2", "--case-indent", "--binary-next-line", "--simplify" },
+        }),
         formatting.stylua,
         formatting.ruff,
       },


### PR DESCRIPTION
# Overview

shfmt によるフォーマットを引数で指定する

- indent: 2
- switch-caseをインデントしない
- `&&` や `|` で始まるようにする
