### PR TITLE
remove: 消し忘れたタスクを削除

### DIFF
--- a/script/tasks/tool.toml
+++ b/script/tasks/tool.toml
@@ -14,7 +14,6 @@ run_task = { name = ["install_cli", "install_gui", "setup_starship"] }
 run_task = [
   { name = [
     "update_package_tools",
-    "update_cli",
     "update_starship",
     "update_rust_tools",
   ] },


### PR DESCRIPTION
# Overview

#329 で消し忘れた `update_cli` タスクを削除
