### PR TITLE
change: `install-and-update` workflow の実行時間を変更する

### DIFF
--- a/.github/workflows/install-and-update.yaml
+++ b/.github/workflows/install-and-update.yaml
@@ -3,7 +3,7 @@ on:
   workflow_call:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * 1'
 jobs:
   exec-install-and-update-task:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Overview

GitHub Actions を使いすぎているので実行時間を毎週月曜日にする
